### PR TITLE
feat: 持倉歷史價格與歷史比例追蹤

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ config/
 # Added by cargo
 
 /target
+
+# Persisted portfolio history
+/data

--- a/src/api/pyth.rs
+++ b/src/api/pyth.rs
@@ -7,6 +7,80 @@ use tokio::sync::Mutex;
 use std::sync::Arc;
 
 const BASE_URL: &str = "https://hermes.pyth.network";
+const BENCHMARKS_URL: &str = "https://benchmarks.pyth.network";
+
+/// Map a portfolio `(symbol, category)` to a Pyth Benchmarks TradingView symbol.
+/// Returns `None` for categories Pyth does not cover (e.g. Taiwan equities).
+pub fn pyth_tv_symbol(symbol: &str, category: &str) -> Option<String> {
+    let sym = symbol.to_uppercase();
+    match category {
+        "Crypto" => Some(format!("Crypto.{}/USD", sym)),
+        "US-Stock" | "US-ETF" => Some(format!("Equity.US.{}/USD", sym)),
+        // For forex we always price against USD, e.g. USD/TWD.
+        "Forex" => Some(format!("FX.USD/{}", sym)),
+        _ => None,
+    }
+}
+
+/// Fetch historical daily close prices from the Pyth Benchmarks TradingView shim.
+///
+/// `tv_symbol` is a Pyth TradingView symbol (e.g. `Equity.US.AAPL/USD`).
+/// `from`/`to` are unix epoch seconds. Returns `(timestamp, close)` pairs.
+pub async fn get_history_from_pyth(
+    tv_symbol: &str,
+    from: i64,
+    to: i64,
+) -> Result<Vec<(i64, f64)>, String> {
+    let url = format!(
+        "{}/v1/shims/tradingview/history?symbol={}&resolution=D&from={}&to={}",
+        BENCHMARKS_URL, tv_symbol, from, to
+    );
+
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(10))
+        .build()
+        .map_err(|e| e.to_string())?;
+
+    let response = client
+        .get(&url)
+        .send()
+        .await
+        .map_err(|e| format!("[Pyth] Failed to query {}: {}", tv_symbol, e))?;
+
+    if !response.status().is_success() {
+        return Err(format!("[Pyth] HTTP error: {}", response.status()));
+    }
+
+    let json: serde_json::Value = response
+        .json()
+        .await
+        .map_err(|e| format!("[Pyth] JSON format error: {}", e))?;
+
+    match json.get("s").and_then(|s| s.as_str()) {
+        Some("ok") => {}
+        other => {
+            return Err(format!(
+                "[Pyth] No history for {} (status: {:?})",
+                tv_symbol, other
+            ));
+        }
+    }
+
+    let times = json.get("t").and_then(|v| v.as_array());
+    let closes = json.get("c").and_then(|v| v.as_array());
+
+    match (times, closes) {
+        (Some(times), Some(closes)) => {
+            let series = times
+                .iter()
+                .zip(closes.iter())
+                .filter_map(|(t, c)| Some((t.as_i64()?, c.as_f64()?)))
+                .collect();
+            Ok(series)
+        }
+        _ => Err(format!("[Pyth] Malformed history response for {}", tv_symbol)),
+    }
+}
 
 pub trait PriceContainer {
     fn update(&mut self, symbol: String, price: f64);
@@ -85,6 +159,36 @@ pub async fn get_pyth_feed_id(symbol: &str, category: &str) -> String {
         .unwrap_or_else(|| panic!("Cannot find feed_id, symbol = {}", symbol));
     let raw = feed_id.as_str().expect("feed_id should be a string");
     return raw.to_string();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_pyth_tv_symbol() {
+        assert_eq!(pyth_tv_symbol("eth", "Crypto").unwrap(), "Crypto.ETH/USD");
+        assert_eq!(pyth_tv_symbol("aapl", "US-Stock").unwrap(), "Equity.US.AAPL/USD");
+        assert_eq!(pyth_tv_symbol("QQQ", "US-ETF").unwrap(), "Equity.US.QQQ/USD");
+        assert_eq!(pyth_tv_symbol("TWD", "Forex").unwrap(), "FX.USD/TWD");
+        assert!(pyth_tv_symbol("2330", "TW-Stock").is_none());
+    }
+
+    #[tokio::test]
+    async fn test_get_history_from_pyth() {
+        if !matches!(std::env::var("RUN_LIVE_PRICE_TESTS").as_deref(), Ok("1")) {
+            return;
+        }
+        let to = chrono::Utc::now().timestamp();
+        let from = to - 30 * 86_400;
+        let series = get_history_from_pyth("Equity.US.AAPL/USD", from, to)
+            .await
+            .unwrap();
+        assert!(!series.is_empty());
+        assert!(series.iter().all(|(_, c)| *c > 0.0));
+        // Timestamps should be strictly increasing.
+        assert!(series.windows(2).all(|w| w[0].0 < w[1].0));
+    }
 }
 
 pub fn spawn_price_stream<C>(

--- a/src/api/yahoo.rs
+++ b/src/api/yahoo.rs
@@ -13,6 +13,8 @@ struct Chart {
 
 #[derive(Deserialize, Debug)]
 struct ChartResult {
+    #[serde(default)]
+    timestamp: Vec<i64>,
     indicators: Indicators,
 }
 
@@ -61,6 +63,64 @@ pub async fn get_price_from_yahoo(symbol: &str) -> Result<f64, String> {
         Some(price) => Ok(price),
         None => Err(format!("[Yahoo] Failed to get closing price for {}", symbol)),
     }
+}
+
+/// Fetch historical daily close prices from Yahoo Finance.
+///
+/// `range` is a Yahoo range string (e.g. `3mo`, `1y`) and `interval` the bar
+/// size (e.g. `1d`). Returns `(timestamp, close)` pairs, skipping null closes.
+/// Used as the historical fallback for Taiwan equities, which Pyth does not cover.
+pub async fn get_history_from_yahoo(
+    symbol: &str,
+    range: &str,
+    interval: &str,
+) -> Result<Vec<(i64, f64)>, String> {
+    let url = format!(
+        "https://query1.finance.yahoo.com/v8/finance/chart/{}?interval={}&range={}",
+        symbol, interval, range
+    );
+
+    let client = Client::builder()
+        .timeout(std::time::Duration::from_secs(10))
+        .build()
+        .map_err(|e| e.to_string())?;
+
+    let response = client
+        .get(&url)
+        .send()
+        .await
+        .map_err(|e| format!("[Yahoo] Failed to query history {}: {}", symbol, e))?;
+
+    if !response.status().is_success() {
+        return Err(format!("[Yahoo] HTTP error: {}", response.status()));
+    }
+
+    let data: YahooChartResponse = response
+        .json()
+        .await
+        .map_err(|e| format!("[Yahoo] JSON format error: {}", e))?;
+
+    let result = data
+        .chart
+        .result
+        .as_ref()
+        .and_then(|r| r.get(0))
+        .ok_or_else(|| format!("[Yahoo] No history result for {}", symbol))?;
+
+    let quote = result
+        .indicators
+        .quote
+        .get(0)
+        .ok_or_else(|| format!("[Yahoo] No quote data for {}", symbol))?;
+
+    let series = result
+        .timestamp
+        .iter()
+        .zip(quote.close.iter())
+        .filter_map(|(t, c)| c.map(|close| (*t, close)))
+        .collect();
+
+    Ok(series)
 }
 
 #[cfg(test)]

--- a/src/get.rs
+++ b/src/get.rs
@@ -1,8 +1,9 @@
 // use crate::api::alpha_vantage::get_price_from_alpha_vantage;
 // use crate::api::binance::get_price_from_binance;
+use crate::api::pyth::{get_history_from_pyth, pyth_tv_symbol};
 use crate::api::redstone::get_price_from_redstone;
 use crate::api::twse::get_price_from_twse;
-use crate::api::yahoo::get_price_from_yahoo;
+use crate::api::yahoo::{get_history_from_yahoo, get_price_from_yahoo};
 
 pub async fn get_price(symbol: &str, category: &str) -> Result<f64, String> {
     match category {
@@ -59,6 +60,33 @@ pub async fn get_price(symbol: &str, category: &str) -> Result<f64, String> {
                 "Failed to get Taiwan stock price (possibly due to API limit or invalid symbol: {})",
                 symbol
             ));
+        }
+
+        _ => Err(format!("Unknown asset category: {}", category)),
+    }
+}
+
+/// Fetch historical daily close prices for a holding between `from` and `to`
+/// (unix epoch seconds). Pyth Benchmarks is the primary source for crypto, US
+/// equities/ETFs and forex; Taiwan equities fall back to Yahoo since Pyth does
+/// not cover them. Returns `(timestamp, close)` pairs.
+pub async fn get_history(
+    symbol: &str,
+    category: &str,
+    from: i64,
+    to: i64,
+) -> Result<Vec<(i64, f64)>, String> {
+    match category {
+        "Crypto" | "US-Stock" | "US-ETF" | "Forex" => {
+            let tv_symbol = pyth_tv_symbol(symbol, category)
+                .ok_or_else(|| format!("No Pyth symbol mapping for {} ({})", symbol, category))?;
+            get_history_from_pyth(&tv_symbol, from, to).await
+        }
+
+        "TW-Stock" | "TW-ETF" => {
+            // Pyth has no Taiwan equities; Yahoo needs the .TW suffix.
+            let yahoo_symbol = format!("{}.TW", symbol);
+            get_history_from_yahoo(&yahoo_symbol, "1y", "1d").await
         }
 
         _ => Err(format!("Unknown asset category: {}", category)),

--- a/src/history.rs
+++ b/src/history.rs
@@ -1,0 +1,258 @@
+use std::collections::HashMap;
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::path::Path;
+
+use chrono::Utc;
+
+use crate::types::{Portfolio, PortfolioSnapshot};
+
+/// Default location for the persisted history (JSON-Lines, one snapshot per line).
+pub const HISTORY_PATH: &str = "data/history.jsonl";
+
+/// Compute the USD value of each portfolio category given a price map.
+///
+/// This is the single source of truth for the "value an item in USD" logic and
+/// is reused by the live allocation view, the snapshot recorder and the
+/// historical back-fill. Forex holdings are merged into a synthetic `Cash`
+/// category to match the live allocation display.
+///
+/// Returns `(category -> usd value, total usd value)`. Missing prices count as 0.
+pub fn compute_category_values(
+    portfolio: &Portfolio,
+    map: &HashMap<String, f64>,
+) -> (HashMap<String, f64>, f64) {
+    let mut categories: HashMap<String, f64> = HashMap::new();
+    let mut total = 0.0;
+
+    for (category, items) in portfolio.group_by_category() {
+        let mut category_value = 0.0;
+
+        for item in &items {
+            let usd_value = if category == "TW-Stock" || category == "TW-ETF" {
+                match (map.get(&item.symbol), map.get("USD/TWD")) {
+                    (Some(price), Some(rate)) if *rate != 0.0 => price * item.quantity / rate,
+                    _ => 0.0,
+                }
+            } else if category == "Forex" {
+                if item.symbol == "USD" {
+                    item.quantity
+                } else {
+                    match map.get(&format!("USD/{}", item.symbol)) {
+                        Some(rate) if *rate != 0.0 => item.quantity / rate,
+                        _ => 0.0,
+                    }
+                }
+            } else {
+                // Crypto, US-Stock, US-ETF are already priced in USD.
+                map.get(&item.symbol).map(|p| p * item.quantity).unwrap_or(0.0)
+            };
+
+            category_value += usd_value;
+        }
+
+        if category_value > 0.0 {
+            // Merge cash-like holdings under a single "Cash" bucket.
+            let key = if category == "Forex" { "Cash".to_string() } else { category };
+            *categories.entry(key).or_insert(0.0) += category_value;
+            total += category_value;
+        }
+    }
+
+    (categories, total)
+}
+
+/// Build a snapshot of the portfolio from the current price map.
+pub fn take_snapshot(portfolio: &Portfolio, map: &HashMap<String, f64>) -> PortfolioSnapshot {
+    let (category_values, total_value_usd) = compute_category_values(portfolio, map);
+    PortfolioSnapshot {
+        timestamp: Utc::now().timestamp(),
+        total_value_usd,
+        category_values,
+        prices: map.clone(),
+    }
+}
+
+/// Load all snapshots from the JSON-Lines history file. Returns an empty vector
+/// if the file does not exist. Malformed lines are skipped.
+pub fn load_history(path: &str) -> Vec<PortfolioSnapshot> {
+    let content = match fs::read_to_string(path) {
+        Ok(c) => c,
+        Err(_) => return Vec::new(),
+    };
+
+    let mut snapshots: Vec<PortfolioSnapshot> = content
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .filter_map(|line| serde_json::from_str(line).ok())
+        .collect();
+
+    snapshots.sort_by_key(|s| s.timestamp);
+    snapshots
+}
+
+/// Append a single snapshot as one JSON line, creating the parent directory and
+/// file as needed.
+pub fn append_snapshot(path: &str, snapshot: &PortfolioSnapshot) -> Result<(), String> {
+    if let Some(parent) = Path::new(path).parent() {
+        fs::create_dir_all(parent).map_err(|e| format!("Failed to create data dir: {}", e))?;
+    }
+
+    let line = serde_json::to_string(snapshot)
+        .map_err(|e| format!("Failed to serialize snapshot: {}", e))?;
+
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .map_err(|e| format!("Failed to open history file: {}", e))?;
+
+    writeln!(file, "{}", line).map_err(|e| format!("Failed to write snapshot: {}", e))
+}
+
+/// Overwrite the history file with the full set of snapshots (one JSON line
+/// each). Used after a back-fill merge to keep the file de-duplicated.
+pub fn save_all(path: &str, history: &[PortfolioSnapshot]) -> Result<(), String> {
+    if let Some(parent) = Path::new(path).parent() {
+        fs::create_dir_all(parent).map_err(|e| format!("Failed to create data dir: {}", e))?;
+    }
+
+    let mut out = String::new();
+    for snap in history {
+        let line = serde_json::to_string(snap)
+            .map_err(|e| format!("Failed to serialize snapshot: {}", e))?;
+        out.push_str(&line);
+        out.push('\n');
+    }
+
+    fs::write(path, out).map_err(|e| format!("Failed to write history file: {}", e))
+}
+
+/// Merge new snapshots into an existing (timestamp-sorted) history, dropping
+/// duplicates that fall on the same UTC day, then return the sorted result.
+/// Existing entries win over new ones for the same day.
+pub fn merge_snapshots(
+    existing: Vec<PortfolioSnapshot>,
+    incoming: Vec<PortfolioSnapshot>,
+) -> Vec<PortfolioSnapshot> {
+    let mut by_day: HashMap<i64, PortfolioSnapshot> = HashMap::new();
+
+    // Incoming first so existing entries overwrite them on collision.
+    for snap in incoming.into_iter().chain(existing.into_iter()) {
+        let day = snap.timestamp.div_euclid(86_400);
+        by_day.insert(day, snap);
+    }
+
+    let mut merged: Vec<PortfolioSnapshot> = by_day.into_values().collect();
+    merged.sort_by_key(|s| s.timestamp);
+    merged
+}
+
+/// Export the history as CSV (timestamp, total_value_usd, then one column per
+/// category) for analysis in external tools.
+pub fn export_csv(history: &[PortfolioSnapshot], path: &str) -> Result<(), String> {
+    // Collect the union of category names for a stable header.
+    let mut categories: Vec<String> = history
+        .iter()
+        .flat_map(|s| s.category_values.keys().cloned())
+        .collect();
+    categories.sort();
+    categories.dedup();
+
+    let mut out = String::from("timestamp,total_value_usd");
+    for cat in &categories {
+        out.push(',');
+        out.push_str(cat);
+    }
+    out.push('\n');
+
+    for snap in history {
+        out.push_str(&format!("{},{:.4}", snap.timestamp, snap.total_value_usd));
+        for cat in &categories {
+            let v = snap.category_values.get(cat).copied().unwrap_or(0.0);
+            out.push_str(&format!(",{:.4}", v));
+        }
+        out.push('\n');
+    }
+
+    if let Some(parent) = Path::new(path).parent() {
+        fs::create_dir_all(parent).map_err(|e| format!("Failed to create dir: {}", e))?;
+    }
+    fs::write(path, out).map_err(|e| format!("Failed to write CSV: {}", e))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn item(symbol: &str, category: &str, quantity: f64) -> crate::types::PortfolioItem {
+        crate::types::PortfolioItem {
+            symbol: symbol.to_string(),
+            category: category.to_string(),
+            quantity,
+        }
+    }
+
+    #[test]
+    fn test_compute_category_values() {
+        let portfolio = Portfolio(vec![
+            item("AAPL", "US-Stock", 10.0),
+            item("2330", "TW-Stock", 10.0),
+            item("USD", "Forex", 100.0),
+            item("TWD", "Forex", 3000.0),
+        ]);
+
+        let mut map = HashMap::new();
+        map.insert("AAPL".to_string(), 200.0); // 2000 USD
+        map.insert("2330".to_string(), 600.0); // 6000 TWD
+        map.insert("USD/TWD".to_string(), 30.0); // -> 200 USD (stock), 100 USD (cash)
+
+        let (cats, total) = compute_category_values(&portfolio, &map);
+        assert!((cats["US-Stock"] - 2000.0).abs() < 1e-6);
+        assert!((cats["TW-Stock"] - 200.0).abs() < 1e-6);
+        // Cash = 100 USD + 3000 TWD / 30 = 100 + 100 = 200
+        assert!((cats["Cash"] - 200.0).abs() < 1e-6);
+        assert!((total - 2400.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_roundtrip_persistence() {
+        let dir = std::env::temp_dir().join(format!("price_hist_{}", std::process::id()));
+        let path = dir.join("history.jsonl");
+        let path_str = path.to_str().unwrap();
+        let _ = fs::remove_file(path_str);
+
+        let mut snap = PortfolioSnapshot {
+            timestamp: 1_700_000_000,
+            total_value_usd: 1234.5,
+            category_values: HashMap::from([("US-Stock".to_string(), 1234.5)]),
+            prices: HashMap::from([("AAPL".to_string(), 123.45)]),
+        };
+        append_snapshot(path_str, &snap).unwrap();
+        snap.timestamp = 1_700_086_400;
+        append_snapshot(path_str, &snap).unwrap();
+
+        let loaded = load_history(path_str);
+        assert_eq!(loaded.len(), 2);
+        assert_eq!(loaded[0].timestamp, 1_700_000_000);
+        assert!((loaded[1].total_value_usd - 1234.5).abs() < 1e-6);
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_merge_dedupes_by_day() {
+        let mk = |ts: i64, v: f64| PortfolioSnapshot {
+            timestamp: ts,
+            total_value_usd: v,
+            category_values: HashMap::new(),
+            prices: HashMap::new(),
+        };
+        // Two snapshots on the same UTC day; existing should win.
+        let existing = vec![mk(1_700_000_000, 100.0)];
+        let incoming = vec![mk(1_700_003_600, 999.0), mk(1_700_200_000, 50.0)];
+        let merged = merge_snapshots(existing, incoming);
+        assert_eq!(merged.len(), 2);
+        assert!((merged[0].total_value_usd - 100.0).abs() < 1e-6);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod api;
 pub mod config;
 pub mod get;
+pub mod history;
 pub mod stream;
 pub mod tui;
 pub mod types;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ use config::read_portfolio;
 mod api;
 mod config;
 mod get;
+mod history;
 mod tui;
 mod types;
 mod stream;

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -5,7 +5,7 @@ use ratatui::{
     Terminal,
     backend::CrosstermBackend,
 };
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 use tokio::sync::Mutex;
 use std::time::Duration;
@@ -14,11 +14,18 @@ use chrono_tz::Asia::Taipei;
 
 use crate::api::pyth::{get_price_stream_from_pyth, get_pyth_feed_id, spawn_price_stream};
 use crate::api::twse::get_close_price_from_twse;
-use crate::get::get_price;
-use crate::tui;
-use crate::types::Portfolio;
+use crate::get::{get_history, get_price};
+use crate::history;
+use crate::tui::{self, ViewMode};
+use crate::types::{Portfolio, PortfolioSnapshot};
 
 type SharedPriceMap = Arc<tokio::sync::Mutex<HashMap<String, f64>>>;
+type SharedHistory = Arc<tokio::sync::Mutex<Vec<PortfolioSnapshot>>>;
+
+/// How often a live snapshot of the portfolio is recorded (seconds).
+const SNAPSHOT_INTERVAL_SECS: u64 = 300;
+/// How far back the historical back-fill reaches (seconds).
+const BACKFILL_WINDOW_SECS: i64 = 365 * 86_400;
 
 /// Check if Taiwan Stock Exchange (TWSE) market is currently open
 /// TWSE trading hours: 09:00 - 13:30 (Monday to Friday)
@@ -42,18 +49,20 @@ fn is_twse_market_open() -> bool {
 
 pub async fn stream(cycle: u64, portfolio: Portfolio, target_forex: &str) {
     let prices = Arc::new(Mutex::new(HashMap::new()));
+    let history: SharedHistory = Arc::new(Mutex::new(history::load_history(history::HISTORY_PATH)));
     // Start background tasks
-    start_background_tasks(&prices, &portfolio, cycle, target_forex).await;
+    start_background_tasks(&prices, &history, &portfolio, cycle, target_forex).await;
     // Setup terminal
     let mut terminal = setup_terminal();
     // Main display loop
-    run_display_loop(&mut terminal, &prices, &portfolio, target_forex).await;
+    run_display_loop(&mut terminal, &prices, &history, &portfolio, target_forex).await;
     // Cleanup
     disable_raw_mode().unwrap();
 }
 
 async fn start_background_tasks(
     prices: &SharedPriceMap,
+    history: &SharedHistory,
     portfolio: &Portfolio,
     cycle: u64,
     target_forex: &str,
@@ -79,6 +88,122 @@ async fn start_background_tasks(
     tokio::spawn(async move {
         polling_stream(polling_prices, cycle, polling_portfolio).await;
     });
+
+    // Back-fill historical daily data once at startup.
+    let backfill_history = history.clone();
+    let backfill_portfolio = portfolio.clone();
+    tokio::spawn(async move {
+        backfill_history_task(backfill_history, backfill_portfolio).await;
+    });
+
+    // Record periodic live snapshots into the history.
+    let snapshot_history = history.clone();
+    let snapshot_prices = prices.clone();
+    let snapshot_portfolio = portfolio.clone();
+    tokio::spawn(async move {
+        snapshot_recorder(snapshot_history, snapshot_prices, snapshot_portfolio).await;
+    });
+}
+
+/// Reconstruct daily historical snapshots from API back-fill using the current
+/// holdings, then merge with any existing on-disk history and persist.
+async fn backfill_history_task(history: SharedHistory, portfolio: Portfolio) {
+    let to = Utc::now().timestamp();
+    let from = to - BACKFILL_WINDOW_SECS;
+
+    // (price-map key, fetch symbol, category)
+    let mut requests: Vec<(String, String, String)> = Vec::new();
+    let mut has_tw = false;
+    let mut has_twd_forex = false;
+
+    for item in portfolio.iter() {
+        match item.category.as_str() {
+            "Forex" => {
+                if item.symbol == "USD" {
+                    continue; // USD is the base currency; no rate needed.
+                }
+                if item.symbol == "TWD" {
+                    has_twd_forex = true;
+                }
+                requests.push((
+                    format!("USD/{}", item.symbol),
+                    item.symbol.clone(),
+                    "Forex".to_string(),
+                ));
+            }
+            "TW-Stock" | "TW-ETF" => {
+                has_tw = true;
+                requests.push((item.symbol.clone(), item.symbol.clone(), item.category.clone()));
+            }
+            _ => {
+                requests.push((item.symbol.clone(), item.symbol.clone(), item.category.clone()));
+            }
+        }
+    }
+
+    // TW holdings need a USD/TWD rate even if TWD isn't held as cash.
+    if has_tw && !has_twd_forex {
+        requests.push(("USD/TWD".to_string(), "TWD".to_string(), "Forex".to_string()));
+    }
+
+    // Bucket every fetched close into a per-UTC-day price map.
+    let mut day_maps: BTreeMap<i64, HashMap<String, f64>> = BTreeMap::new();
+    for (key, symbol, category) in requests {
+        match get_history(&symbol, &category, from, to).await {
+            Ok(series) => {
+                for (ts, price) in series {
+                    let day = ts.div_euclid(86_400);
+                    day_maps.entry(day).or_default().insert(key.clone(), price);
+                }
+            }
+            Err(e) => eprintln!("[backfill] {} ({}) failed: {}", symbol, category, e),
+        }
+    }
+
+    // Rebuild a snapshot for each day using current quantities.
+    let mut backfilled = Vec::new();
+    for (day, map) in day_maps {
+        let (category_values, total) = history::compute_category_values(&portfolio, &map);
+        if total <= 0.0 {
+            continue;
+        }
+        backfilled.push(PortfolioSnapshot {
+            timestamp: day * 86_400,
+            total_value_usd: total,
+            category_values,
+            prices: map,
+        });
+    }
+
+    // Merge with existing history (existing wins per day) and persist.
+    let mut guard = history.lock().await;
+    let existing = std::mem::take(&mut *guard);
+    let merged = history::merge_snapshots(existing, backfilled);
+    if let Err(e) = history::save_all(history::HISTORY_PATH, &merged) {
+        eprintln!("[backfill] failed to save history: {}", e);
+    }
+    *guard = merged;
+}
+
+/// Append a live snapshot of the portfolio at a fixed interval.
+async fn snapshot_recorder(history: SharedHistory, prices: SharedPriceMap, portfolio: Portfolio) {
+    let mut interval = tokio::time::interval(Duration::from_secs(SNAPSHOT_INTERVAL_SECS));
+    interval.tick().await; // Skip the immediate first tick.
+
+    loop {
+        interval.tick().await;
+
+        let map = { prices.lock().await.clone() };
+        let snapshot = history::take_snapshot(&portfolio, &map);
+        if snapshot.total_value_usd <= 0.0 {
+            continue; // Skip until prices are populated.
+        }
+
+        if let Err(e) = history::append_snapshot(history::HISTORY_PATH, &snapshot) {
+            eprintln!("[snapshot] failed to persist: {}", e);
+        }
+        history.lock().await.push(snapshot);
+    }
 }
 
 async fn start_forex_stream(prices: SharedPriceMap, forex_symbol: &str) {
@@ -136,24 +261,46 @@ fn setup_terminal() -> Terminal<CrosstermBackend<std::io::Stdout>> {
 async fn run_display_loop(
     terminal: &mut Terminal<CrosstermBackend<std::io::Stdout>>,
     prices: &SharedPriceMap,
+    history: &SharedHistory,
     portfolio: &Portfolio,
     target_forex: &str,
 ) {
+    let mut view_mode = ViewMode::Live;
+
     loop {
-        // Check for 'q' key press to exit
+        // Handle key presses: 'q' quits, 'h'/'l' switch history/live views.
         if event::poll(Duration::from_millis(10)).unwrap() {
             if let Event::Key(key_event) = event::read().unwrap() {
-                if key_event.code == KeyCode::Char('q') {
-                    break;
+                match key_event.code {
+                    KeyCode::Char('q') => break,
+                    KeyCode::Char('h') => view_mode = ViewMode::History,
+                    KeyCode::Char('l') => view_mode = ViewMode::Live,
+                    KeyCode::Char('e') => {
+                        let snapshot = { history.lock().await.clone() };
+                        if let Err(e) = history::export_csv(&snapshot, "data/history.csv") {
+                            eprintln!("[export] {}", e);
+                        }
+                    }
+                    _ => {}
                 }
             }
         }
 
         let map = prices.lock().await;
         let (lines, total_value) = build_portfolio_display(&map, portfolio).await;
+        let history_snapshot = { history.lock().await.clone() };
 
         // Render display
-        tui::render_portfolio(terminal, &lines, total_value, &map, target_forex, portfolio);
+        tui::render_portfolio(
+            terminal,
+            &lines,
+            total_value,
+            &map,
+            target_forex,
+            portfolio,
+            &history_snapshot,
+            view_mode,
+        );
 
         tokio::time::sleep(Duration::from_millis(50)).await;
     }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1,5 +1,6 @@
 use ratatui::{
-    widgets::{Block, Paragraph, Borders, Gauge},
+    widgets::{Block, Paragraph, Borders, Axis, Chart, Dataset, GraphType},
+    symbols,
     Terminal,
     backend::CrosstermBackend,
     style::{Style, Color},
@@ -8,7 +9,27 @@ use ratatui::{
 };
 
 use std::collections::HashMap;
-use crate::types::Portfolio;
+use chrono::{TimeZone, Utc};
+use crate::history::compute_category_values;
+use crate::types::{Portfolio, PortfolioSnapshot};
+
+/// Which screen the TUI is currently showing.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum ViewMode {
+    Live,
+    History,
+}
+
+/// Stable palette shared by the allocation view and the history charts so a
+/// category keeps the same colour across screens.
+const PALETTE: [Color; 6] = [
+    Color::Blue,
+    Color::Red,
+    Color::Yellow,
+    Color::Magenta,
+    Color::Cyan,
+    Color::Green,
+];
 
 pub fn render_portfolio(
     terminal: &mut Terminal<CrosstermBackend<std::io::Stdout>>,
@@ -17,7 +38,14 @@ pub fn render_portfolio(
     map: &HashMap<String, f64>,
     target_forex: &str,
     portfolio: &Portfolio,
+    history: &[PortfolioSnapshot],
+    view_mode: ViewMode,
 ) {
+    if view_mode == ViewMode::History {
+        terminal.draw(|f| render_history(f, f.area(), history)).unwrap();
+        return;
+    }
+
     terminal.draw(|f| {
         let area = f.area();
 
@@ -50,7 +78,7 @@ pub fn render_portfolio(
         }
 
         let portfolio_block = Block::default()
-            .title("Portfolio")
+            .title("Portfolio (h: history  e: export csv  q: quit)")
             .borders(Borders::ALL);
         let portfolio_paragraph = Paragraph::new(display_lines).block(portfolio_block);
         f.render_widget(portfolio_paragraph, chunks[0]);
@@ -67,66 +95,13 @@ fn render_asset_allocation(
     map: &HashMap<String, f64>,
     total_value: f64,
 ) {
-    // Calculate asset category values using Portfolio data
-    let mut categories = HashMap::new();
-    let colors = [Color::Blue, Color::Red, Color::Yellow, Color::Magenta, Color::Cyan, Color::Green];
-
-    // Use Portfolio items directly instead of parsing strings
-    let grouped_portfolio = portfolio.group_by_category();
-    for (category, items) in grouped_portfolio.iter() {
-        let mut category_value = 0.0;
-
-        for item in items {
-            let usd_value = if category == "TW-Stock" || category == "TW-ETF" {
-                // Convert TWD to USD
-                if let Some(price) = map.get(&item.symbol) {
-                    let asset_value = price * item.quantity;
-                    if let Some(rate) = map.get("USD/TWD") {
-                        asset_value / rate
-                    } else {
-                        0.0
-                    }
-                } else {
-                    0.0
-                }
-            } else if category == "Forex" {
-                // Handle forex conversion - forex assets don't need price lookup
-                if item.symbol == "USD" {
-                    item.quantity
-                } else {
-                    let forex_key = format!("USD/{}", item.symbol);
-                    if let Some(forex_rate) = map.get(&forex_key) {
-                        item.quantity / forex_rate
-                    } else {
-                        0.0
-                    }
-                }
-            } else {
-                // Crypto, US-Stock, US-ETF are already in USD
-                if let Some(price) = map.get(&item.symbol) {
-                    price * item.quantity
-                } else {
-                    0.0
-                }
-            };
-
-            category_value += usd_value;
-        }
-
-        if category_value > 0.0 {
-            // Merge cash categories
-            let final_category = if category == "Forex" {
-                "Cash"
-            } else {
-                category.as_str()
-            };
-            *categories.entry(final_category).or_insert(0.0) += category_value;
-        }
-    }
+    // Calculate asset category values using the shared helper.
+    let colors = PALETTE;
+    let (categories, _total) = compute_category_values(portfolio, map);
 
     // Sort categories by value (largest to smallest)
     let mut sorted_categories: Vec<(&str, f64)> = categories.iter()
-        .map(|(k, &v)| (*k, v))
+        .map(|(k, &v)| (k.as_str(), v))
         .collect();
     sorted_categories.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
 
@@ -187,4 +162,141 @@ fn render_asset_allocation(
         let bar_paragraph = Paragraph::new(vec![combined_bar]);
         f.render_widget(bar_paragraph, bar_area);
     }
+}
+
+/// History screen: total portfolio value over time (top) and per-category
+/// allocation ratio over time (bottom).
+fn render_history(
+    f: &mut ratatui::Frame,
+    area: ratatui::layout::Rect,
+    history: &[PortfolioSnapshot],
+) {
+    if history.len() < 2 {
+        let msg = Paragraph::new(
+            "Collecting history... (need at least 2 data points)\nPress 'l' for live view, 'q' to quit",
+        )
+        .block(Block::default().title("History").borders(Borders::ALL));
+        f.render_widget(msg, area);
+        return;
+    }
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Percentage(55), Constraint::Percentage(45)])
+        .split(area);
+
+    render_total_value_chart(f, chunks[0], history);
+    render_ratio_chart(f, chunks[1], history);
+}
+
+fn date_labels(x_min: f64, x_max: f64) -> Vec<Span<'static>> {
+    let fmt = |ts: f64| {
+        Utc.timestamp_opt(ts as i64, 0)
+            .single()
+            .map(|d| d.format("%m/%d").to_string())
+            .unwrap_or_default()
+    };
+    let mid = (x_min + x_max) / 2.0;
+    vec![Span::raw(fmt(x_min)), Span::raw(fmt(mid)), Span::raw(fmt(x_max))]
+}
+
+fn render_total_value_chart(
+    f: &mut ratatui::Frame,
+    area: ratatui::layout::Rect,
+    history: &[PortfolioSnapshot],
+) {
+    let data: Vec<(f64, f64)> = history
+        .iter()
+        .map(|s| (s.timestamp as f64, s.total_value_usd))
+        .collect();
+
+    let x_min = data.first().map(|p| p.0).unwrap_or(0.0);
+    let x_max = data.last().map(|p| p.0).unwrap_or(1.0);
+    let y_max = data.iter().map(|(_, y)| *y).fold(0.0_f64, f64::max);
+    let y_hi = if y_max > 0.0 { y_max * 1.1 } else { 1.0 };
+
+    let datasets = vec![
+        Dataset::default()
+            .name("Total (USD)")
+            .marker(symbols::Marker::Braille)
+            .graph_type(GraphType::Line)
+            .style(Style::default().fg(Color::Green))
+            .data(&data),
+    ];
+
+    let chart = Chart::new(datasets)
+        .block(
+            Block::default()
+                .title("Total Value History (USD)  l: live  q: quit")
+                .borders(Borders::ALL),
+        )
+        .x_axis(Axis::default().bounds([x_min, x_max]).labels(date_labels(x_min, x_max)))
+        .y_axis(Axis::default().bounds([0.0, y_hi]).labels(vec![
+            Span::raw("$0".to_string()),
+            Span::raw(format!("${:.0}", y_hi / 2.0)),
+            Span::raw(format!("${:.0}", y_hi)),
+        ]));
+
+    f.render_widget(chart, area);
+}
+
+fn render_ratio_chart(
+    f: &mut ratatui::Frame,
+    area: ratatui::layout::Rect,
+    history: &[PortfolioSnapshot],
+) {
+    // Stable, alphabetically-ordered union of category names.
+    let mut cats: Vec<String> = history
+        .iter()
+        .flat_map(|s| s.category_values.keys().cloned())
+        .collect();
+    cats.sort();
+    cats.dedup();
+
+    let x_min = history.first().map(|s| s.timestamp as f64).unwrap_or(0.0);
+    let x_max = history.last().map(|s| s.timestamp as f64).unwrap_or(1.0);
+
+    // Build and keep the per-category point series alive for the datasets.
+    let series: Vec<(String, Vec<(f64, f64)>)> = cats
+        .iter()
+        .map(|cat| {
+            let pts: Vec<(f64, f64)> = history
+                .iter()
+                .filter(|s| s.total_value_usd > 0.0)
+                .map(|s| {
+                    let v = s.category_values.get(cat).copied().unwrap_or(0.0);
+                    (s.timestamp as f64, v / s.total_value_usd * 100.0)
+                })
+                .collect();
+            (cat.clone(), pts)
+        })
+        .collect();
+
+    let datasets: Vec<Dataset> = series
+        .iter()
+        .enumerate()
+        .map(|(i, (name, data))| {
+            Dataset::default()
+                .name(name.clone())
+                .marker(symbols::Marker::Braille)
+                .graph_type(GraphType::Line)
+                .style(Style::default().fg(PALETTE[i % PALETTE.len()]))
+                .data(data)
+        })
+        .collect();
+
+    let chart = Chart::new(datasets)
+        .block(
+            Block::default()
+                .title("Allocation Ratio History (%)")
+                .borders(Borders::ALL),
+        )
+        .x_axis(Axis::default().bounds([x_min, x_max]).labels(date_labels(x_min, x_max)))
+        .y_axis(Axis::default().bounds([0.0, 100.0]).labels(vec![
+            Span::raw("0%"),
+            Span::raw("50%"),
+            Span::raw("100%"),
+        ]));
+
+    f.render_widget(chart, area);
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone)]
 pub struct Portfolio(pub Vec<PortfolioItem>);
@@ -49,6 +49,20 @@ pub struct PortfolioItem {
     pub symbol: String,
     pub category: String,
     pub quantity: f64,
+}
+
+/// A point-in-time snapshot of the portfolio, used to build historical
+/// price and allocation series. Persisted as one JSON line per snapshot.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PortfolioSnapshot {
+    /// Unix epoch seconds.
+    pub timestamp: i64,
+    /// Total portfolio value expressed in USD.
+    pub total_value_usd: f64,
+    /// Category -> USD value. Allocation ratio = value / total_value_usd.
+    pub category_values: HashMap<String, f64>,
+    /// Per-symbol price at this point in time (the historical price).
+    pub prices: HashMap<String, f64>,
 }
 
 #[derive(Debug, Deserialize)]


### PR DESCRIPTION
## 背景

`price` 原本是完全無狀態的即時投資組合工具：價格只存在記憶體、關閉即遺失，比例每幀即時計算只反映「當下」，沒有任何時間序列或圖表。本 PR 新增一條獨立的「歷史」資料流，讓持倉的**價值走勢**與**各類別比例變化**能跨時間查看，且不破壞現有即時畫面。

## 變更內容

### 資料來源
- **Pyth Benchmarks 為主**（`src/api/pyth.rs` 的 `get_history_from_pyth`）：與 app 即時價格同源，涵蓋 Crypto / US 股票 / US-ETF / Forex。每個標的一次 HTTP 請求即取得整段每日序列，大幅降低對 Yahoo 的請求量。
- **Yahoo 僅作台股 fallback**（`get_history_from_yahoo`，自動補 `.TW` 後綴），因台股不在 Pyth 涵蓋範圍。
- `src/get.rs` 新增 `get_history` 依類別分派。

### 核心
- `src/history.rs`（新檔）：JSON-Lines 持久化（`load`/`append`/`save_all`）、依 UTC 日去重合併、CSV 匯出，以及共用的 `compute_category_values` —— 即時比例檢視、快照、回補三處皆複用，移除原本重複的 USD 換算邏輯。
- `src/types.rs`：新增 `PortfolioSnapshot`（timestamp / 總 USD 值 / 各類別值 / 各標的價格）。
- `src/stream.rs`：啟動時一次性**回補**（用目前持倉數量 × 歷史收盤重建每日總值與比例），執行期間每 5 分鐘**快照**追加。
- `src/tui.rs`：用 ratatui 內建 `Chart` 新增歷史檢視——上方總值折線圖、下方各類別比例折線圖。

### 操作鍵
- `h` 歷史檢視 · `l` 即時檢視 · `e` 匯出 `data/history.csv` · `q` 離開
- `data/` 已加入 `.gitignore`

## 測試
- `cargo test` 全綠（15 passed），含 `history.rs` 的換算 / 持久化 / 合併單元測試與 Pyth 整合測試。
- 以 `RUN_LIVE_PRICE_TESTS=1` 實測 Pyth Benchmarks 端點可用。
- 新增程式碼無編譯警告。
- 註：TUI 需要 TTY，圖表畫面未在無頭環境端對端實跑；邏輯已分別由單元測試與 live 測試覆蓋。本機 `cargo run` 後按 `h` 可見回補的歷史曲線。

https://claude.ai/code/session_01D1dsLvz4Fa8ZHgvxup1Axv

---
_Generated by [Claude Code](https://claude.ai/code/session_01D1dsLvz4Fa8ZHgvxup1Axv)_