### PR TITLE
fix: tolerate missing api_key.toml and target_forex.toml

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -11,7 +11,13 @@ pub fn read_portfolio(path: &str) -> Portfolio {
 }
 
 pub fn read_api_keys(path: &str) -> Result<HashMap<String, String>, String> {
-    let content = fs::read_to_string(path).map_err(|e| format!("Failed to read file: {}", e))?;
+    let content = match fs::read_to_string(path) {
+        Ok(content) => content,
+        // A missing api key file is not fatal: callers that need a specific key
+        // will surface a clear "key not found" error instead.
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(HashMap::new()),
+        Err(e) => return Err(format!("Failed to read file: {}", e)),
+    };
     let keys: ApiKeys = toml::from_str(&content).map_err(|e| format!("Failed to parse TOML: {}", e))?;
     Ok(keys.0)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,15 @@ async fn main() {
     let portfolio = read_portfolio(portfolio_path);
 
     let target_forex_path = "config/target_forex.toml";
-    let target_forex: &str = &config::read_target_forex(target_forex_path).unwrap();
+    let target_forex: String = match config::read_target_forex(target_forex_path) {
+        Ok(forex) => forex,
+        Err(e) => {
+            eprintln!(
+                "[config] {} not usable ({}); defaulting target forex to USD",
+                target_forex_path, e
+            );
+            "USD".to_string()
+        }
+    };
     stream::stream(5, portfolio, &target_forex).await;
 }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -67,13 +67,15 @@ async fn start_background_tasks(
     cycle: u64,
     target_forex: &str,
 ) {
-    let forex_symbol = format!("USD/{}", target_forex);
-    println!("Subscribing to forex rate: {}", forex_symbol);
-
     seed_twse_cache(prices.clone(), portfolio).await;
 
-    // Start forex stream
-    start_forex_stream(prices.clone(), &forex_symbol).await;
+    // Start forex stream. USD/USD is trivially 1.0 and has no Pyth feed, so
+    // skip subscribing when the display currency is already USD.
+    if !target_forex.eq_ignore_ascii_case("USD") {
+        let forex_symbol = format!("USD/{}", target_forex);
+        println!("Subscribing to forex rate: {}", forex_symbol);
+        start_forex_stream(prices.clone(), &forex_symbol).await;
+    }
 
     // Start lazy stream
     let lazy_prices = prices.clone();


### PR DESCRIPTION
Default target forex to USD and warn instead of panicking when config/target_forex.toml is absent or invalid. Treat a missing config/api_key.toml as an empty key set rather than an error.

https://claude.ai/code/session_01D1dsLvz4Fa8ZHgvxup1Axv