### PR TITLE
feat: resolve #6 — bug: get_history() ignores from/to date range for TW-Stock/TW-ETF — always fetches 1 year

### DIFF
--- a/src/api/yahoo.rs
+++ b/src/api/yahoo.rs
@@ -130,6 +130,68 @@ pub async fn get_history_from_yahoo(
     Ok(series)
 }
 
+/// Fetch historical daily close prices for a precise epoch-second window.
+///
+/// Uses Yahoo's `period1`/`period2` query parameters instead of a coarse
+/// `range` bucket, so the fetched series matches the caller-supplied window
+/// without over-fetching. Results are also filtered to `[from, to]` as a
+/// safety net against off-by-one or timezone edge cases.
+pub async fn get_history_from_yahoo_range(
+    symbol: &str,
+    from: i64,
+    to: i64,
+    interval: &str,
+) -> Result<Vec<(i64, f64)>, String> {
+    let url = format!(
+        "https://query1.finance.yahoo.com/v8/finance/chart/{}?interval={}&period1={}&period2={}",
+        symbol, interval, from, to
+    );
+
+    let client = Client::builder()
+        .timeout(std::time::Duration::from_secs(10))
+        .user_agent(USER_AGENT)
+        .build()
+        .map_err(|e| e.to_string())?;
+
+    let response = client
+        .get(&url)
+        .send()
+        .await
+        .map_err(|e| format!("[Yahoo] Failed to query history {}: {}", symbol, e))?;
+
+    if !response.status().is_success() {
+        return Err(format!("[Yahoo] HTTP error: {}", response.status()));
+    }
+
+    let data: YahooChartResponse = response
+        .json()
+        .await
+        .map_err(|e| format!("[Yahoo] JSON format error: {}", e))?;
+
+    let result = data
+        .chart
+        .result
+        .as_ref()
+        .and_then(|r| r.get(0))
+        .ok_or_else(|| format!("[Yahoo] No history result for {}", symbol))?;
+
+    let quote = result
+        .indicators
+        .quote
+        .get(0)
+        .ok_or_else(|| format!("[Yahoo] No quote data for {}", symbol))?;
+
+    let series = result
+        .timestamp
+        .iter()
+        .zip(quote.close.iter())
+        .filter_map(|(t, c)| c.map(|close| (*t, close)))
+        .filter(|(t, _)| *t >= from && *t <= to)
+        .collect();
+
+    Ok(series)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/get.rs
+++ b/src/get.rs
@@ -3,7 +3,7 @@
 use crate::api::pyth::{get_history_from_pyth, pyth_tv_symbol};
 use crate::api::redstone::get_price_from_redstone;
 use crate::api::twse::get_price_from_twse;
-use crate::api::yahoo::{get_history_from_yahoo, get_price_from_yahoo};
+use crate::api::yahoo::{get_history_from_yahoo_range, get_price_from_yahoo};
 
 pub async fn get_price(symbol: &str, category: &str) -> Result<f64, String> {
     match category {
@@ -86,7 +86,7 @@ pub async fn get_history(
         "TW-Stock" | "TW-ETF" => {
             // Pyth has no Taiwan equities; Yahoo needs the .TW suffix.
             let yahoo_symbol = format!("{}.TW", symbol);
-            get_history_from_yahoo(&yahoo_symbol, "1y", "1d").await
+            get_history_from_yahoo_range(&yahoo_symbol, from, to, "1d").await
         }
 
         _ => Err(format!("Unknown asset category: {}", category)),
@@ -118,5 +118,26 @@ mod tests {
         assert!(price.is_err()); // Crypto fetching is currently disabled
         let price = get_price("AAPL", "Unknown").await;
         assert!(price.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_get_history_tw_respects_range() {
+        if !live_price_tests_enabled() {
+            return;
+        }
+        let to = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64;
+        let from = to - 30 * 86_400;
+
+        for (symbol, category) in [("2330", "TW-Stock"), ("0050", "TW-ETF")] {
+            let series = get_history(symbol, category, from, to).await.unwrap();
+            assert!(!series.is_empty(), "{} ({}) returned no history", symbol, category);
+            for (ts, _) in &series {
+                assert!(*ts >= from, "{}: timestamp {} < from {}", symbol, ts, from);
+                assert!(*ts <= to, "{}: timestamp {} > to {}", symbol, ts, to);
+            }
+        }
     }
 }


### PR DESCRIPTION
Closes #6. Generated and verified by the nightly bot.