### PR TITLE
docs: document 57 undocumented public item(s)

### DIFF
--- a/src/api/alpha_vantage.rs
+++ b/src/api/alpha_vantage.rs
@@ -1,3 +1,5 @@
+//! Alpha Vantage price source.
+
 use crate::config::read_api_keys;
 use crate::types::PriceResponse;
 

--- a/src/api/binance.rs
+++ b/src/api/binance.rs
@@ -1,3 +1,5 @@
+//! Binance spot price source.
+
 use reqwest::Client;
 use serde::Deserialize;
 
@@ -6,6 +8,11 @@ struct BinancePrice {
     price: String,
 }
 
+/// Fetch the latest spot price for `symbol` quoted in USDT.
+///
+/// `symbol` is upper-cased and suffixed with `USDT` to form the Binance trading
+/// pair (e.g. `BTC` queries `BTCUSDT`). Returns the parsed price, or an `Err`
+/// string describing a request, HTTP, JSON or parse failure.
 pub async fn get_price_from_binance(symbol: &str) -> Result<f64, String> {
     let pair = format!("{}USDT", symbol.to_uppercase());
     let url = format!("https://api.binance.com/api/v3/ticker/price?symbol={}", pair);

--- a/src/api/exchangerate.rs
+++ b/src/api/exchangerate.rs
@@ -1,3 +1,5 @@
+//! ExchangeRate-API forex rate source.
+
 use reqwest::Client;
 use serde::Deserialize;
 
@@ -10,6 +12,12 @@ struct ExchangeRateResponse {
     rates: std::collections::HashMap<String, f64>,
 }
 
+/// Fetch the conversion rate from currency `from` to currency `to`.
+///
+/// Both codes are upper-cased. Requires `exchangerate_api_key` in the API key
+/// file. Returns the rate, or an `Err` string if the key is missing, the request
+/// or HTTP call fails, the response status is not `"success"`, or `to` is absent
+/// from the returned rate table.
 pub async fn get_rate(from: &str, to: &str) -> Result<f64, String> {
     let api_keys = read_api_keys(&crate::paths::api_key_file())
         .map_err(|e| format!("[ExchangeRate] Failed to read API key: {}", e))?;

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,3 +1,5 @@
+//! Price and history data providers, one submodule per upstream API.
+
 pub mod alpha_vantage;
 pub mod binance;
 pub mod exchangerate;

--- a/src/api/pyth.rs
+++ b/src/api/pyth.rs
@@ -1,3 +1,6 @@
+//! Pyth Network price source: real-time SSE price streams and Pyth Benchmarks
+//! historical data.
+
 use eventsource_client::Client as EventSourceClient; // 避免與 reqwest::Client 衝突
 use eventsource_client::{ClientBuilder, SSE};
 use launchdarkly_sdk_transport::HyperTransport;
@@ -91,7 +94,12 @@ pub async fn get_history_from_pyth(
     }
 }
 
+/// A collection of `(symbol, price)` entries that a price stream can write into.
+///
+/// Implemented for both `Vec<(String, f64)>` and `HashMap<String, f64>` so the
+/// streaming code can update either an ordered list or a keyed map.
 pub trait PriceContainer {
+    /// Set `symbol` to `price`, replacing any existing entry for that symbol.
     fn update(&mut self, symbol: String, price: f64);
 }
 
@@ -161,6 +169,12 @@ where
     Ok(())
 }
 
+/// Look up the Pyth price-feed id for `(symbol, category)` in the bundled feed
+/// table.
+///
+/// `symbol` is upper-cased before lookup. Returns an `Err` string if the
+/// category is absent from the table, the symbol is absent within it, or the
+/// stored id is not a string.
 pub fn get_pyth_feed_id(symbol: &str, category: &str) -> Result<String, String> {
     let target = symbol.to_uppercase();
     let feeds = PYTH_FEEDS
@@ -260,6 +274,12 @@ where
     }
 }
 
+/// Spawn a background task that streams live prices for `(symbol, category)`
+/// into `prices`, keyed by `symbol`.
+///
+/// Resolves the feed id via [`get_pyth_feed_id`]; if no feed exists for the
+/// holding the task logs and exits, otherwise it runs [`stream_into_map`]
+/// (reconnecting indefinitely). Returns immediately.
 pub fn spawn_price_stream<C>(
     symbol: &str,
     category: &str,

--- a/src/api/redstone.rs
+++ b/src/api/redstone.rs
@@ -1,3 +1,5 @@
+//! RedStone price source.
+
 use reqwest::Client;
 use serde::Deserialize;
 
@@ -6,6 +8,11 @@ struct RedstonePrice {
     value: f64,
 }
 
+/// Fetch the latest price for `symbol` from RedStone.
+///
+/// `symbol` is upper-cased before querying. Returns the most recent price value,
+/// or an `Err` string on request, HTTP or JSON failure, or when RedStone returns
+/// no price data for the symbol.
 pub async fn get_price_from_redstone(symbol: &str) -> Result<f64, String> {
     let symbol = symbol.to_uppercase();
     let url = format!(

--- a/src/api/twse.rs
+++ b/src/api/twse.rs
@@ -1,3 +1,5 @@
+//! Taiwan Stock Exchange (TWSE) price source.
+
 use reqwest::Client;
 use serde::Deserialize;
 
@@ -15,6 +17,12 @@ struct TwseStock {
     y: String, // Previous close
 }
 
+/// Fetch the current price of TWSE-listed stock `symbol` (e.g. `2330`).
+///
+/// Uses the last traded price when available; if it is `"-"`, falls back to the
+/// geometric mean of the best ask and bid, and if those cannot be parsed, to the
+/// previous close. Returns an `Err` string on request, HTTP, JSON, missing-data
+/// or parse failure.
 pub async fn get_price_from_twse(symbol: &str) -> Result<f64, String> {
     let pair = format!("tse_{}.tw", symbol);
     let url = format!(
@@ -71,6 +79,10 @@ pub async fn get_price_from_twse(symbol: &str) -> Result<f64, String> {
     }
 }
 
+/// Fetch the previous-close price of TWSE-listed stock `symbol`.
+///
+/// Returns the previous close (the `y` field), or an `Err` string on request,
+/// HTTP, JSON, missing-data or parse failure.
 pub async fn get_close_price_from_twse(symbol: &str) -> Result<f64, String> {
     let pair = format!("tse_{}.tw", symbol);
     let url = format!(

--- a/src/api/yahoo.rs
+++ b/src/api/yahoo.rs
@@ -1,3 +1,5 @@
+//! Yahoo Finance price and history source.
+
 use reqwest::Client;
 use serde::Deserialize;
 
@@ -33,6 +35,10 @@ struct Quote {
     close: Vec<Option<f64>>, // Some time points may be null
 }
 
+/// Fetch the latest daily close price for `symbol` from Yahoo Finance.
+///
+/// Queries a one-day chart and returns the last non-null close. Returns an `Err`
+/// string on request, HTTP or JSON failure, or when no closing price is present.
 pub async fn get_price_from_yahoo(symbol: &str) -> Result<f64, String> {
     let url = format!(
         "https://query1.finance.yahoo.com/v8/finance/chart/{}?interval=1d&range=1d",

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,9 +1,18 @@
+//! Reading and parsing of the TOML configuration files: portfolio holdings,
+//! API keys and the display (target) currency.
+
 use std::collections::HashMap;
 use std::fs;
 use toml;
 
 use crate::types::{ApiKeys, Portfolio};
 
+/// Read and parse the portfolio TOML file at `path`.
+///
+/// # Panics
+///
+/// Panics if the file cannot be read or its contents are not valid portfolio
+/// TOML. Use [`try_read_portfolio`] for a non-panicking variant.
 pub fn read_portfolio(path: &str) -> Portfolio {
     let content = fs::read_to_string(path).expect("Failed to read portfolio file");
     let portfolio: Portfolio = toml::from_str(&content).expect("Failed to parse portfolio TOML");
@@ -18,6 +27,10 @@ pub fn try_read_portfolio(path: &str) -> Result<Portfolio, String> {
     toml::from_str(&content).map_err(|e| format!("Failed to parse TOML: {}", e))
 }
 
+/// Read the API key TOML file at `path` into a `name -> key` map.
+///
+/// A missing file is not an error: it yields an empty map. Returns an `Err`
+/// string if the file exists but cannot be read or parsed.
 pub fn read_api_keys(path: &str) -> Result<HashMap<String, String>, String> {
     let content = match fs::read_to_string(path) {
         Ok(content) => content,
@@ -30,6 +43,10 @@ pub fn read_api_keys(path: &str) -> Result<HashMap<String, String>, String> {
     Ok(keys.0)
 }
 
+/// Read the display currency from the `target` field of the TOML file at `path`.
+///
+/// Returns an `Err` string if the file cannot be read or parsed, or if the
+/// `target` field is missing or not a string.
 pub fn read_target_forex(path: &str) -> Result<String, String> {
     let content = fs::read_to_string(path).map_err(|e| format!("Failed to read file: {}", e))?;
     let value: toml::Value = toml::from_str(&content).map_err(|e| format!("Failed to parse TOML: {}", e))?;

--- a/src/get.rs
+++ b/src/get.rs
@@ -1,3 +1,6 @@
+//! Category-aware price and history lookup that selects and falls back across
+//! the provider APIs.
+
 // use crate::api::alpha_vantage::get_price_from_alpha_vantage;
 // use crate::api::binance::get_price_from_binance;
 use crate::api::pyth::{get_history_from_pyth, pyth_tv_symbol};
@@ -5,6 +8,11 @@ use crate::api::redstone::get_price_from_redstone;
 use crate::api::twse::get_price_from_twse;
 use crate::api::yahoo::{get_history_from_yahoo_range, get_price_from_yahoo};
 
+/// Fetch the current price of `symbol` for the given asset `category`.
+///
+/// `US-Stock`/`US-ETF` try RedStone then Yahoo; `TW-Stock`/`TW-ETF` try TWSE
+/// then Yahoo. Returns an `Err` string for an unknown category, for `Crypto`
+/// (currently disabled), or when every source for the category fails.
 pub async fn get_price(symbol: &str, category: &str) -> Result<f64, String> {
     match category {
         /*

--- a/src/history.rs
+++ b/src/history.rs
@@ -1,3 +1,6 @@
+//! Portfolio snapshot history: computing category values, recording snapshots
+//! to the JSONL store, loading them back and exporting to CSV.
+
 use std::collections::HashMap;
 use std::fs;
 use std::path::Path;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,10 @@
+//! Library crate for the `price` portfolio tracker.
+//!
+//! It fetches asset prices and historical series from several providers
+//! ([`api`]), reads the user's holdings and settings from TOML files
+//! ([`config`], [`paths`], [`types`]), records periodic snapshots
+//! ([`history`]), and renders a live terminal UI ([`tui`], [`stream`]).
+
 pub mod api;
 pub mod config;
 pub mod get;

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,3 +1,6 @@
+//! Process-wide file logging that degrades to a silent no-op when the log file
+//! cannot be opened, so diagnostics never corrupt the TUI.
+
 use std::fs::OpenOptions;
 use std::io::Write;
 use std::path::Path;
@@ -37,7 +40,7 @@ pub fn init() {
     });
 }
 
-/// Append one timestamped line to the log file. Used by the [`log_line!`] macro;
+/// Append one timestamped line to the log file. Used by the [`crate::log_line!`] macro;
 /// prefer the macro at call sites.
 pub fn write_line(args: std::fmt::Arguments<'_>) {
     let Some(Some(lock)) = LOG.get() else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,9 @@
+//! Binary entry point for the `price` portfolio tracker.
+//!
+//! Installs the rustls crypto provider, initialises file logging, loads the
+//! portfolio and display currency from the config files, and hands off to the
+//! streaming TUI.
+
 use config::read_portfolio;
 
 mod api;

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -25,25 +25,30 @@ pub fn data_dir() -> String {
     env::var("PRICE_DATA_DIR").unwrap_or_else(|_| DEFAULT_DATA_DIR.to_string())
 }
 
+/// Path to the portfolio file: `<config dir>/portfolio.toml`.
 pub fn portfolio_file() -> String {
     format!("{}/portfolio.toml", config_dir())
 }
 
+/// Path to the display-currency file: `<config dir>/target_forex.toml`.
 pub fn target_forex_file() -> String {
     format!("{}/target_forex.toml", config_dir())
 }
 
 // Only referenced by the AlphaVantage/ExchangeRate sources, which are currently
 // disabled; kept so they resolve the path consistently once re-enabled.
+/// Path to the API key file: `<config dir>/api_key.toml`.
 #[allow(dead_code)]
 pub fn api_key_file() -> String {
     format!("{}/api_key.toml", config_dir())
 }
 
+/// Path to the snapshot history file: `<data dir>/history.jsonl`.
 pub fn history_file() -> String {
     format!("{}/history.jsonl", data_dir())
 }
 
+/// Path to the CSV export of the history: `<data dir>/history.csv`.
 pub fn history_csv_file() -> String {
     format!("{}/history.csv", data_dir())
 }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1,3 +1,7 @@
+//! The running application: spawns the live price streams and background tasks,
+//! drives the TUI display loop, and polls Taiwan-market prices and config
+//! hot-reloads.
+
 use futures::stream::{FuturesUnordered, StreamExt};
 use crossterm::terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen};
 use crossterm::{execute, cursor, event::{self, Event, KeyCode}};
@@ -58,6 +62,13 @@ fn is_twse_market_open() -> bool {
     current_time >= open_time && current_time < close_time
 }
 
+/// Run the application: start the background price/snapshot/reload tasks, set up
+/// the terminal, run the display loop until the user quits, then restore the
+/// terminal.
+///
+/// `cycle` is the Taiwan-market polling interval in seconds, `portfolio` the
+/// initial holdings and `target_forex` the initial display currency. Returns
+/// when the user exits the display loop.
 pub async fn stream(cycle: u64, portfolio: Portfolio, target_forex: String) {
     let prices: SharedPriceMap = Arc::new(Mutex::new(HashMap::new()));
     let history: SharedHistory = Arc::new(Mutex::new(history::load_history(&paths::history_file())));
@@ -567,6 +578,12 @@ async fn build_portfolio_display(
     (lines, total_value)
 }
 
+/// Poll Taiwan-market (`TW-Stock`, `TW-ETF`) prices every `cycle` seconds and
+/// write them into `prices`.
+///
+/// Loops forever. The first immediate tick is skipped, and cycles where the TWSE
+/// market is closed are skipped (cached prices remain). Holdings are re-read from
+/// `portfolio` each cycle so hot-reloaded changes are picked up.
 pub async fn polling_stream(prices: SharedPriceMap, cycle: u64, portfolio: SharedPortfolio) {
     let mut interval = tokio::time::interval(Duration::from_secs(cycle));
     // Skip the first immediate tick

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1,3 +1,6 @@
+//! Terminal UI rendering: the live portfolio/allocation screen and the
+//! historical value and allocation-ratio charts.
+
 use ratatui::{
     widgets::{Block, Paragraph, Borders, Axis, Chart, Dataset, GraphType},
     symbols,
@@ -16,7 +19,9 @@ use crate::types::{Portfolio, PortfolioSnapshot};
 /// Which screen the TUI is currently showing.
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum ViewMode {
+    /// The live portfolio and asset-allocation screen.
     Live,
+    /// The historical value and allocation-ratio screen.
     History,
 }
 
@@ -42,6 +47,12 @@ const PALETTE: [Color; 6] = [
     Color::Green,
 ];
 
+/// Render one frame to `terminal` for the current `view_mode`.
+///
+/// In [`ViewMode::History`] it draws the history charts from `history`.
+/// Otherwise it draws the portfolio lines plus the total value in USD (and, when
+/// a `USD/<target_forex>` rate is present in `map`, the total converted to the
+/// target currency), with the asset-allocation panel below.
 pub fn render_portfolio(
     terminal: &mut Terminal<CrosstermBackend<std::io::Stdout>>,
     lines: &[String],

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,6 +1,13 @@
+//! Core data types: the portfolio holdings model, historical snapshots and the
+//! API response/key structures used across the crate.
+
 use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 
+/// A flat list of portfolio holdings.
+///
+/// Deserialized from a nested TOML table of `category -> { symbol -> quantity }`
+/// and flattened into one [`PortfolioItem`] per `(category, symbol)` pair.
 #[derive(Debug, Clone)]
 pub struct Portfolio(pub Vec<PortfolioItem>);
 
@@ -27,10 +34,25 @@ impl<'de> Deserialize<'de> for Portfolio {
 }
 
 impl Portfolio {
+    /// Borrowing iterator over the holdings in storage order.
     pub fn iter(&self) -> std::slice::Iter<'_, PortfolioItem> {
         self.0.iter()
     }
 
+    /// Group the holdings by their `category` field, cloning each item into the
+    /// bucket for its category.
+    ///
+    /// ```
+    /// use price::types::{Portfolio, PortfolioItem};
+    /// let p = Portfolio(vec![
+    ///     PortfolioItem { symbol: "AAPL".into(), category: "US-Stock".into(), quantity: 1.0 },
+    ///     PortfolioItem { symbol: "VOO".into(),  category: "US-Stock".into(), quantity: 2.0 },
+    ///     PortfolioItem { symbol: "BTC".into(),  category: "Crypto".into(),   quantity: 3.0 },
+    /// ]);
+    /// let groups = p.group_by_category();
+    /// assert_eq!(groups["US-Stock"].len(), 2);
+    /// assert_eq!(groups["Crypto"].len(), 1);
+    /// ```
     pub fn group_by_category(&self) -> HashMap<String, Vec<PortfolioItem>> {
         let mut map: HashMap<String, Vec<PortfolioItem>> = HashMap::new();
         for item in &self.0 {
@@ -39,15 +61,29 @@ impl Portfolio {
         map
     }
 
+    /// All holdings in `category`, or `None` if no holding has that category.
+    ///
+    /// ```
+    /// use price::types::{Portfolio, PortfolioItem};
+    /// let p = Portfolio(vec![
+    ///     PortfolioItem { symbol: "AAPL".into(), category: "US-Stock".into(), quantity: 1.0 },
+    /// ]);
+    /// assert!(p.get("US-Stock").is_some());
+    /// assert!(p.get("Crypto").is_none());
+    /// ```
     pub fn get(&self, category: &str) -> Option<Vec<PortfolioItem>> {
         self.group_by_category().get(category).cloned()
     }
 }
 
+/// A single portfolio holding.
 #[derive(Debug, Deserialize, Clone)]
 pub struct PortfolioItem {
+    /// Asset symbol (e.g. `AAPL`, `2330`, `BTC`, `TWD`).
     pub symbol: String,
+    /// Asset category (e.g. `US-Stock`, `TW-Stock`, `Crypto`, `Forex`).
     pub category: String,
+    /// Number of units held.
     pub quantity: f64,
 }
 
@@ -65,15 +101,23 @@ pub struct PortfolioSnapshot {
     pub prices: HashMap<String, f64>,
 }
 
+/// API credentials, deserialized from a flat TOML table of `name -> key`.
 #[derive(Debug, Deserialize)]
 pub struct ApiKeys(pub HashMap<String, String>);
 
+/// A single price quote with its provenance and an optional error.
 #[derive(Debug, Deserialize)]
 pub struct PriceResponse {
+    /// Quoted price.
     pub price: f64,
+    /// Name of the data source that produced the price.
     pub source: String,
+    /// Asset symbol the price is for.
     pub symbol: String,
+    /// Asset category the price is for.
     pub category: String,
+    /// Timestamp of the quote, as a string.
     pub timestamp: String,
+    /// Error message if the quote could not be obtained, otherwise `None`.
     pub error: Option<String>,
 }


### PR DESCRIPTION
**Tier 1 — DRAFT for batch review.** This repo's hard gate can't mechanically
verify every docstring claim, so the verifier agent is the main semantic gate and
a human should confirm before merge. Opened as a draft so it can't be merged by
accident.

**Already checked by machine** (you don't need to re-check these):
- Hard gate passed: `cargo build && cargo test --doc && RUSTDOCFLAGS='-D warnings' cargo doc --no-deps`
- A separate read-only verifier agent fact-checked the diff. Its verdict:

```
=== verifier @ 09:14:38 ===
I've read all the source files referenced by the diff. Here is my fact-check of each added/changed doc claim against the code.

## Verified claims (code-supported)

**Module docs** (`alpha_vantage`, `binance`, `exchangerate`, `pyth`, `redstone`, `twse`, `yahoo`, `mod.rs`, `config`, `get`, `history`, `lib`, `main`, `paths`, `stream`, `tui`, `logging`) — all accurately describe their modules' contents.

**`binance::get_price_from_binance`** — upper-cases symbol, suffixes `USDT` (`format!("{}USDT", symbol.to_uppercase())`), errors on request/HTTP/JSON/parse. ✓ (`binance.rs:17,25-35`)

**`exchangerate::get_rate`** — both codes upper-cased (`from.to_uppercase()`, `to.to_uppercase()`), requires `exchangerate_api_key`, errors on missing key / request / HTTP / `result != "success"` / missing `to`. ✓ (`exchangerate.rs:24-56`)

**`redstone::get_price_from_redstone`** — upper-cases, returns first value, errors on request/HTTP/JSON/no-data. ✓ (`redstone.rs:17,37-43`)

**`twse::get_price_from_twse`** — uses `z` (last traded); on `"-"` falls back to geometric mean `(a*b).sqrt()` of first ask/bid; if unparseable, falls back to previous close `y`. ✓ (`twse.rs:54-76`). `get_close_price_from_twse` returns `y`. ✓

**`yahoo::get_price_from_yahoo`** — 1d chart, `.last().flatten()` returns the last close (non-null, else the "no closing price present" Err branch). The "non-null close … or when no closing price is present" phrasing is consistent with the code. ✓ (`yahoo.rs:42-77`)

**`pyth`** — `PriceContainer` implemented for both `Vec<(String,f64)>` and `HashMap` (✓); `update` replaces existing entry (✓); `get_pyth_feed_id` upper-cases and errors on missing category / missing symbol / non-string id (✓); `spawn_price_stream` resolves id, logs+exits if none else runs `stream_into_map`, returns immediately (✓). (`pyth.rs:101-120,178-189,283-302`)

**`config`** — `read_portfolio` panics on read/parse failure (✓ `expect`); `read_api_keys` treats missing file as empty map (✓ `NotFound => Ok(HashMap::new())`); `read_target_forex` reads `target` field, errors on read/parse/missing/non-string (✓). 

**`get::get_price`** — US-Stock/ETF → RedStone then Yahoo; TW-Stock/ETF → TWSE then Yahoo; Crypto disabled (commented out, falls to `_` Err arm); unknown → Err. ✓ (`get.rs:39-74`)

**`paths`** — all path strings match (`portfolio.toml`, `target_forex.toml`, `api_key.toml`, `history.jsonl`, `history.csv`). ✓

**`stream::stream`** — starts background tasks, sets up terminal, runs loop, restores terminal; `cycle` is TW polling interval. ✓ (`stream.rs:72-86`). **`polling_stream`** — loops forever, skips first tick, skips when market closed, re-reads holdings each cycle. ✓ (`stream.rs:587-603`)

**`logging`** — write_line doc link corrected to `[`crate::log_line!`]`, which resolves correctly since `log_line!` is `#[macro_export]` at crate root. ✓ The "degrades to a silent no-op … so diagnostics never corrupt the TUI" is a consequence of writing to a file + no-op fallback, both present in code — verifiable, not an unverifiable rationale.

**`main`** — installs rustls aws_lc_rs provider, then `logging::init()`, then loads portfolio + target currency, then `stream::stream`. Order and content match. ✓

## Minor notes (not factual errors)
- `get::get_price` doc lists "unknown category" and "Crypto (currently disabled)" as distinct reasons; in code Crypto hits the same `_ => Err("Unknown asset category…")` arm. Both genuinely return `Err`, and crypto branches are in fact commented out, so the claim is accurate, just framed as two cases.

Every factual claim in the diff is supported by the source. No invented signatures, parameters, defaults, or behaviors. The few "why" clauses (logging no-op rationale) are direct, code-verifiable consequences rather than unverifiable design-intent narratives.

VERDICT: PASS
```

**Needs your eyes:** only claims a compiler can't confirm — anything the verifier
flagged or left uncertain above. Everything else is machine-verified.

— scan: public API · docs-bot Tier 1