### PR TITLE
chore: Dependabot + cargo audit + tiered auto-merge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: weekly
+    # Bound CI runs: one PR for all backward-compatible bumps instead of one each.
+    groups:
+      cargo-minor-patch:
+        update-types:
+          - minor
+          - patch
+    open-pull-requests-limit: 5

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,30 @@
+name: Audit
+
+# Supply-chain oracle. "cargo build/test green" can't tell you a dependency has a
+# known RUSTSEC advisory or was yanked — this can. Runs on every PR (so a flagged
+# bump turns the PR red and auto-merge can't fire) and weekly (so a newly-disclosed
+# advisory on an *existing* dependency is caught even with no bump).
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "0 6 * * 1" # Mondays 06:00 UTC
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install cargo-audit
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-audit
+      - name: Ensure a lockfile exists (lib crates may not commit one)
+        run: test -f Cargo.lock || cargo generate-lockfile
+      - name: cargo audit
+        run: cargo audit -D warnings

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,38 @@
+name: Dependabot auto-merge
+
+# Tiered auto-merge gated by semver bump type (the objective, free-to-read oracle):
+#   patch + minor -> enable auto-merge (GitHub merges once required checks pass)
+#   major         -> left untouched for a human (breaking changes get eyes)
+#
+# Auto-merge only WAITS for CI if the branch has required status checks. Without
+# branch protection a PR is instantly mergeable and would merge before CI finishes
+# — so this workflow is only half the gate; branch protection requiring the CI +
+# audit checks is the other half (set by deps-setup.sh phase 2).
+#
+# pull_request_target is deliberate: workflows triggered by Dependabot get a
+# read-only GITHUB_TOKEN by default, so a plain pull_request trigger couldn't merge.
+# pull_request_target runs in the base context where the permissions block applies.
+
+on: pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for patch & minor
+        if: ${{ steps.meta.outputs.update-type == 'version-update:semver-patch' || steps.meta.outputs.update-type == 'version-update:semver-minor' }}
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds dependency automation: weekly grouped Dependabot bumps, a `cargo audit` (RUSTSEC) gate, and tiered auto-merge (patch/minor auto on green CI, major to a human). After merge, re-run deps-setup.sh to enable allow_auto_merge + branch protection (so auto-merge waits for CI).