### PR TITLE
deps: bump quinn-proto 0.11.14 → 0.11.15 (RUSTSEC-2026-0185)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1908,9 +1908,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",


### PR DESCRIPTION
Clears the failing `audit` check that's currently blocking every open price PR (e.g. #23, #24).

**What:** `cargo update -p quinn-proto --precise 0.11.15` — `Cargo.lock`-only, version + checksum.

**Why:** [RUSTSEC-2026-0185](https://rustsec.org/advisories/RUSTSEC-2026-0185.html) (HIGH / CVSS 7.5) — out-of-order QUIC stream-reassembly memory-exhaustion DoS in `quinn-proto < 0.11.15`.

**Risk:** none. `quinn-proto` is pulled only through `reqwest`'s optional `http3` feature, which isn't enabled here (`reqwest = { features = ["json"] }`). `cargo tree -i quinn-proto --target all` resolves to nothing — it's never compiled into the binary. `cargo audit` flags it anyway because it scans the lockfile, so bumping to the patched version is the clean way to make CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)